### PR TITLE
Fix 1 vulnerable dependencies identified by Prisma Cloud

### DIFF
--- a/deps/npm/package.json
+++ b/deps/npm/package.json
@@ -278,7 +278,7 @@
     "deep-equal": "^1.0.1",
     "get-stream": "^4.1.0",
     "licensee": "^7.0.3",
-    "marked": "^0.6.3",
+    "marked": "1.1.1",
     "marked-man": "^0.6.0",
     "npm-registry-couchapp": "^2.7.4",
     "npm-registry-mock": "^1.3.1",


### PR DESCRIPTION
Prisma Cloud has detected new vulnerabilities or dependencies in the scan performed on Tue, 06 Jul 2021 12:54:06 UTC

**This PR includes the fixes for the vulnerabilities discovered below:**
Severity | Dependency File | Package name | CVE | Risk Score | Fix Status | Description
-- | -- | -- | -- | -- | -- | --
critical | deps/npm/docs/package-lock.json | xmlhttprequest-ssl | [CVE-2021-31597](https://nvd.nist.gov/vuln/detail/CVE-2021-31597) | 9.4 | fixed in 1.6.1 | The xmlhttprequest-ssl package before 1.6.1 for Node.js disables SSL certificate validation by default, because rejectUnauthorized (when the property exists but is undefined) is considered to be false within the https.request function of Node.js. In other words, no certificate is ever rejected.
high | tools/node-lint-md-cli-rollup/package-lock.json | glob-parent | [CVE-2020-28469](https://nvd.nist.gov/vuln/detail/CVE-2020-28469) | 7.5 | fixed in 5.1.2 | This affects the package glob-parent before 5.1.2. The enclosure regex used to check for strings ending in enclosure containing path separator.
high | tools/node-lint-md-cli-rollup/package-lock.json | path-parse | [CVE-2021-23343](https://nvd.nist.gov/vuln/detail/CVE-2021-23343) | 7.5 | fixed in 1.0.7 | All versions of package path-parse are vulnerable to Regular Expression Denial of Service (ReDoS) via splitDeviceRe, splitTailRe, and splitPathRe regular expressions. ReDoS exhibits polynomial worst-case time complexity.
high | tools/node-lint-md-cli-rollup/package-lock.json | trim | [CVE-2020-7753](https://github.com/advisories/GHSA-w5p7-h5w8-2hfq) | 7.5 | fixed in 0.0.3 | All versions of package trim are vulnerable to Regular Expression Denial of Service (ReDoS) via trim().
high | deps/v8/tools/turbolizer/package-lock.json | pathval | [CVE-2020-7751](https://nvd.nist.gov/vuln/detail/CVE-2020-7751) | 7.2 | fixed in 1.1.1 | pathval before version 1.1.1 is vulnerable to prototype pollution.
high | deps/v8/tools/turbolizer/package-lock.json | path-parse | [CVE-2021-23343](https://nvd.nist.gov/vuln/detail/CVE-2021-23343) | 7.5 | fixed in 1.0.7 | All versions of package path-parse are vulnerable to Regular Expression Denial of Service (ReDoS) via splitDeviceRe, splitTailRe, and splitPathRe regular expressions. ReDoS exhibits polynomial worst-case time complexity.
high | tools/doc/package-lock.json | trim | [CVE-2020-7753](https://github.com/advisories/GHSA-w5p7-h5w8-2hfq) | 7.5 | fixed in 0.0.3 | All versions of package trim are vulnerable to Regular Expression Denial of Service (ReDoS) via trim().
high | deps/npm/docs/package-lock.json | lodash | [CVE-2020-8203](https://nvd.nist.gov/vuln/detail/CVE-2020-8203) | 7.4 | fixed in 4.17.19 | Prototype pollution attack when using _.zipObjectDeep in lodash before 4.17.20.
high | deps/npm/docs/package-lock.json | lodash | [CVE-2021-23337](https://nvd.nist.gov/vuln/detail/CVE-2021-23337) | 7.2 | fixed in 4.17.21 | Lodash versions prior to 4.17.21 are vulnerable to Command Injection via the template function.
high | deps/npm/docs/package-lock.json | bl | [CVE-2020-8244](https://nvd.nist.gov/vuln/detail/CVE-2020-8244) | 6.5 | fixed in 2.2.1, 1.2.3, 4.0.3, 3.0.1 | A buffer over-read vulnerability exists in bl <4.0.3, <3.0.1, <2.2.1, and <1.2.3 which could allow an attacker to supply user input (even typed) that if it ends up in consume() argument and can become negative, the BufferList state can be corrupted, tricking it into exposing uninitialized memory via regular .slice() calls.
high | deps/npm/docs/package-lock.json | trim | [CVE-2020-7753](https://github.com/advisories/GHSA-w5p7-h5w8-2hfq) | 7.5 | fixed in 0.0.3 | All versions of package trim are vulnerable to Regular Expression Denial of Service (ReDoS) via trim().
high | deps/npm/docs/package-lock.json | url-parse | [CVE-2021-27515](https://nvd.nist.gov/vuln/detail/CVE-2021-27515) | 5.3 | fixed in 1.5.0 | url-parse before 1.5.0 mishandles certain uses of backslash such as http:\\/ and interprets the URI as a relative path.
high | deps/npm/docs/package-lock.json | node-forge | [CVE-2020-7720](https://nvd.nist.gov/vuln/detail/CVE-2020-7720) | 7.3 | fixed in 0.10.0 | The package node-forge before 0.10.0 is vulnerable to Prototype Pollution via the util.setPath function. Note: Version 0.10.0 is a breaking change removing the vulnerable functions.
high | deps/npm/docs/package-lock.json | prismjs | [CVE-2020-15138](https://nvd.nist.gov/vuln/detail/CVE-2020-15138) | 7.5 | fixed in 1.21.0 | Prism is vulnerable to Cross-Site Scripting. The easing preview of the Previewers plugin has an XSS vulnerability that allows attackers to execute arbitrary code in Safari and Internet Explorer. This impacts all Safari and Internet Explorer users of Prism >=v1.1.0 that use the _Previewers_ plugin (>=v1.10.0) or the _Previewer: Easing_ plugin (v1.1.0 to v1.9.0). This problem is fixed in version 1.21.0. To workaround the issue without upgrading, disable the easing preview on all impacted code blocks. You need Prism v1.10.0 or newer to apply this workaround.
high | deps/npm/docs/package-lock.json | prismjs | [CVE-2021-23341](https://github.com/advisories/GHSA-h4hr-7fg3-h35w) | 7.5 | fixed in 1.23.0 | The package prismjs before 1.23.0 are vulnerable to Regular Expression Denial of Service (ReDoS) via the prism-asciidoc, prism-rest, prism-tap and prism-eiffel components.
high | deps/npm/docs/package-lock.json | prismjs | [CVE-2021-32723](https://github.com/advisories/GHSA-gj77-59wh-66hg) | 6.5 | fixed in 1.24.0 | Prism is a syntax highlighting library. Some languages before 1.24.0 are vulnerable to Regular Expression Denial of Service (ReDoS). When Prism is used to highlight untrusted (user-given) text, an attacker can craft a string that will take a very very long time to highlight. This problem has been fixed in Prism v1.24. As a workaround, do not use ASCIIDoc or ERB to highlight untrusted text. Other languages are not affected and can be used to highlight untrusted text.
high | deps/npm/docs/package-lock.json | is-svg | [CVE-2021-28092](https://github.com/advisories/GHSA-7r28-3m3f-r2pr) | 7.5 | fixed in 4.2.2 | The is-svg package 2.1.0 through 4.2.1 for Node.js uses a regular expression that is vulnerable to Regular Expression Denial of Service (ReDoS). If an attacker provides a malicious string, is-svg will get stuck processing the input for a very long time.
high | deps/npm/docs/package-lock.json | socket.io-parser | [CVE-2020-36049](https://nvd.nist.gov/vuln/detail/CVE-2020-36049) | 7.5 | fixed in 3.4.1, 3.3.2 | socket.io-parser before 3.4.1 allows attackers to cause a denial of service (memory consumption) via a large packet because a concatenation approach is used.
high | deps/npm/docs/package-lock.json | trim-newlines | [CVE-2021-33623](https://nvd.nist.gov/vuln/detail/CVE-2021-33623) | 7.5 | fixed in 4.0.1, 3.0.1 | The trim-newlines package before 3.0.1 and 4.x before 4.0.1 for Node.js has an issue related to regular expression denial-of-service (ReDoS) for the .end() method.
high | deps/npm/docs/package-lock.json | axios | [CVE-2020-28168](https://nvd.nist.gov/vuln/detail/CVE-2020-28168) | 5.9 | fixed in 0.21.1 | Axios NPM package 0.21.0 contains a Server-Side Request Forgery (SSRF) vulnerability where an attacker is able to bypass a proxy by providing a URL that responds with a redirect to a restricted host or IP address.
high | deps/npm/docs/package-lock.json | glob-parent | [CVE-2020-28469](https://nvd.nist.gov/vuln/detail/CVE-2020-28469) | 7.5 | fixed in 5.1.2 | This affects the package glob-parent before 5.1.2. The enclosure regex used to check for strings ending in enclosure containing path separator.
high | deps/npm/docs/package-lock.json | engine.io | [CVE-2020-36048](https://nvd.nist.gov/vuln/detail/CVE-2020-36048) | 7.5 | fixed in 4.0.0 | Engine.IO before 4.0.0 allows attackers to cause a denial of service (resource consumption) via a POST request to the long polling transport.
high | deps/npm/docs/package-lock.json | http-proxy | [GHSA-6x33-pw7p-hmpq]() | 7.0 | fixed in 1.18.1 | Versions of `http-proxy` prior to 1.18.1 are vulnerable to Denial of Service. An HTTP request with a long body triggers an `ERR_HTTP_HEADERS_SENT` unhandled exception that crashes the proxy server. This is only possible when the proxy server sets headers in the proxy request using the `proxyReq.setHeader` function.     For a proxy server running on `http://localhost:3000`, the following curl request triggers the unhandled exception:   ```curl -XPOST http://localhost:3000 -d \"$(python -c \'print(\"x\"*1025)\')\"```   ## Recommendation  Upgrade to version 1.18.1 or later
high | deps/npm/docs/package-lock.json | xmlhttprequest-ssl | [CVE-2020-28502](https://github.com/advisories/GHSA-h4j5-c7cj-74xg) | 8.1 | fixed in 1.6.2 | This affects the package xmlhttprequest before 1.7.0; all versions of package xmlhttprequest-ssl. Provided requests are sent synchronously (async=False on xhr.open), malicious user input flowing into xhr.send could result in arbitrary code being injected and run.
high | deps/npm/docs/package-lock.json | decompress | [CVE-2020-12265](https://nvd.nist.gov/vuln/detail/CVE-2020-12265) | 9.8 | fixed in 4.2.1 | The decompress package before 4.2.1 for Node.js is vulnerable to Arbitrary File Write via ../ in an archive member, when a symlink is used, because of Directory Traversal.
high | deps/npm/docs/package-lock.json | dns-packet | [CVE-2021-23386](https://github.com/advisories/GHSA-3wcq-x3mq-6r9p) | 6.5 | fixed in 1.3.2, 5.2.2 | This affects the package dns-packet before 5.2.2. It creates buffers with allocUnsafe and does not always fill them before forming network packets. This can expose internal application memory over unencrypted network when querying crafted invalid domain names.
high | deps/npm/docs/package-lock.json | elliptic | [CVE-2020-13822](https://nvd.nist.gov/vuln/detail/CVE-2020-13822) | 7.7 | fixed in 6.5.3 | The Elliptic package 6.5.2 for Node.js allows ECDSA signature malleability via variations in encoding, leading \'\0\' bytes, or integer overflows. This could conceivably have a security-relevant impact if an application relied on a single canonical signature.
high | deps/npm/docs/package-lock.json | ua-parser-js | [CVE-2020-7733](https://nvd.nist.gov/vuln/detail/CVE-2020-7733) | 7.5 | fixed in 0.7.22 | The package ua-parser-js before 0.7.22 are vulnerable to Regular Expression Denial of Service (ReDoS) via the regex for Redmi Phones and Mi Pad Tablets UA.
high | deps/npm/docs/package-lock.json | ua-parser-js | [CVE-2020-7793](https://nvd.nist.gov/vuln/detail/CVE-2020-7793) | 7.5 | fixed in 0.7.23 | The package ua-parser-js before 0.7.23 are vulnerable to Regular Expression Denial of Service (ReDoS) in multiple regexes (see linked commit for more info).
high | deps/npm/docs/package-lock.json | ua-parser-js | [CVE-2021-27292](https://nvd.nist.gov/vuln/detail/CVE-2021-27292) | 7.5 | fixed in 0.7.24 | ua-parser-js >= 0.7.14, fixed in 0.7.24, uses a regular expression which is vulnerable to denial of service. If an attacker sends a malicious User-Agent header, ua-parser-js will get stuck processing it for an extended period of time.
high | deps/npm/docs/package-lock.json | ssri | [CVE-2021-27290](https://github.com/advisories/GHSA-vx3p-948g-6vhq) | 7.5 | fixed in 8.0.1, 7.1.1, 6.0.2 | ssri 5.2.2-8.0.0, fixed in 8.0.1, processes SRIs using a regular expression which is vulnerable to a denial of service. Malicious SRIs could take an extremely long time to process, leading to denial of service. This issue only affects consumers using the strict option.
high | deps/npm/docs/package-lock.json | object-path | [CVE-2020-15256](https://nvd.nist.gov/vuln/detail/CVE-2020-15256) | 9.8 | fixed in 0.11.5 | A prototype pollution vulnerability has been found in `object-path` <= 0.11.4 affecting the `set()` method. The vulnerability is limited to the `includeInheritedProps` mode (if version >= 0.11.0 is used), which has to be explicitly enabled by creating a new instance of `object-path` and setting the option `includeInheritedProps: true`, or by using the default `withInheritedProps` instance. The default operating mode is not affected by the vulnerability if version >= 0.11.0 is used. Any usage of `set()` in versions < 0.11.0 is vulnerable. The issue is fixed in object-path version 0.11.5 As a workaround, don\'t use the `includeInheritedProps: true` options or the `withInheritedProps` instance if using a version >= 0.11.0.
high | deps/npm/docs/package-lock.json | path-parse | [CVE-2021-23343](https://nvd.nist.gov/vuln/detail/CVE-2021-23343) | 7.5 | fixed in 1.0.7 | All versions of package path-parse are vulnerable to Regular Expression Denial of Service (ReDoS) via splitDeviceRe, splitTailRe, and splitPathRe regular expressions. ReDoS exhibits polynomial worst-case time complexity.
high | deps/npm/docs/package-lock.json | serialize-javascript | [CVE-2020-7660](https://nvd.nist.gov/vuln/detail/CVE-2020-7660) | 8.1 | fixed in 3.1.0 | serialize-javascript prior to 3.1.0 allows remote attackers to inject arbitrary code via the function \"deleteFunctions\" within \"index.js\".
high | deps/npm/docs/package-lock.json | y18n | [CVE-2020-7774](https://github.com/advisories/GHSA-c4w7-xm78-47vh) | 7.3 | fixed in 5.0.5, 4.0.1, 3.2.2 | This affects the package y18n before 3.2.2, 4.0.1 and 5.0.5. PoC by po6ix: const y18n = require(\'y18n\')(); y18n.setLocale(\'__proto__\'); y18n.updateLocale({polluted: true}); console.log(polluted); // true
high | deps/npm/docs/package-lock.json | graphql-playground-html | [CVE-2020-4038](https://nvd.nist.gov/vuln/detail/CVE-2020-4038) | 7.4 | fixed in 1.6.22 | GraphQL Playground (graphql-playground-html NPM package) before version 1.6.22 have a severe XSS Reflection attack vulnerability. All unsanitized user input passed into renderPlaygroundPage() method could trigger this vulnerability. This has been patched in graphql-playground-html version 1.6.22. Note that some of the associated dependent middleware packages are also affected including but not limited to graphql-playground-middleware-express before version 1.7.16, graphql-playground-middleware-koa before version 1.6.15, graphql-playground-middleware-lambda before version 1.7.17, and graphql-playground-middleware-hapi before 1.6.13.
high | deps/npm/docs/package-lock.json | dot-prop | [CVE-2020-8116](https://nvd.nist.gov/vuln/detail/CVE-2020-8116) | 7.3 | fixed in 5.1.1, 4.2.1 | Prototype pollution vulnerability in dot-prop npm package versions before 4.2.1 and versions 5.x before 5.1.1 allows an attacker to add arbitrary properties to JavaScript language constructs such as objects.
high | test/fixtures/wpt/resources/webidl2/package-lock.json | glob-parent | [CVE-2020-28469](https://nvd.nist.gov/vuln/detail/CVE-2020-28469) | 7.5 | fixed in 5.1.2 | This affects the package glob-parent before 5.1.2. The enclosure regex used to check for strings ending in enclosure containing path separator.
high | tools/clang-format/package-lock.json | path-parse | [CVE-2021-23343](https://nvd.nist.gov/vuln/detail/CVE-2021-23343) | 7.5 | fixed in 1.0.7 | All versions of package path-parse are vulnerable to Regular Expression Denial of Service (ReDoS) via splitDeviceRe, splitTailRe, and splitPathRe regular expressions. ReDoS exhibits polynomial worst-case time complexity.
medium | deps/npm/package.json | marked | [PRISMA-2021-0013]() | 0.0 | fixed in 1.1.1 | marked package prior to 1.1.1 are vulnerable to  Regular Expression Denial of Service (ReDoS). The regex within src/rules.js file have multiple unused capture groups which could lead to a denial of service attack if user input is reachable.  Origin: https://github.com/markedjs/marked/commit/bd4f8c464befad2b304d51e33e89e567326e62e0
moderate | deps/v8/tools/turbolizer/package-lock.json | ws | [CVE-2021-32640](https://github.com/advisories/GHSA-6fc8-4gx4-v693) | 5.3 | fixed in 5.2.3, 6.2.2, 7.4.6 | ws is an open source WebSocket client and server library for Node.js. A specially crafted value of the `Sec-Websocket-Protocol` header can be used to significantly slow down a ws server. The vulnerability has been fixed in ws@7.4.6 (https://github.com/websockets/ws/commit/00c425ec77993773d823f018f64a5c44e17023ff). In vulnerable versions of ws, the issue can be mitigated by reducing the maximum allowed length of the request headers using the [`--max-http-header-size=size`](https://nodejs.org/api/cli.html#cli_max_http_header_size_size) and/or the [`maxHeaderSize`](https://nodejs.org/api/http.html#http_http_createserver_options_requestlistener) options.
moderate | deps/npm/docs/package-lock.json | jpeg-js | [CVE-2020-8175](https://nvd.nist.gov/vuln/detail/CVE-2020-8175) | 5.5 | fixed in 0.4.0 | Uncontrolled resource consumption in `jpeg-js` before 0.4.0 may allow attacker to launch denial of service attacks using specially a crafted JPEG image.
medium | deps/npm/docs/package-lock.json | lodash | [CVE-2020-28500](https://nvd.nist.gov/vuln/detail/CVE-2020-28500) | 5.3 | fixed in 4.17.21 | Lodash versions prior to 4.17.21 are vulnerable to Regular Expression Denial of Service (ReDoS) via the toNumber, trim and trimEnd functions.
moderate | deps/npm/docs/package-lock.json | postcss | [CVE-2021-23368](https://nvd.nist.gov/vuln/detail/CVE-2021-23368) | 5.3 | fixed in 8.2.10, 7.0.36 | The package postcss from 7.0.0 and before 8.2.10 are vulnerable to Regular Expression Denial of Service (ReDoS) during source map parsing.
medium | deps/npm/docs/package-lock.json | postcss | [CVE-2021-23382](https://nvd.nist.gov/vuln/detail/CVE-2021-23382) | 5.3 | fixed in 8.2.13 | The package postcss before 8.2.13 are vulnerable to Regular Expression Denial of Service (ReDoS) via getAnnotationURL() and loadAnnotation() in lib/previous-map.js. The vulnerable regexes are caused mainly by the sub-pattern \\/\\*\\s* sourceMappingURL=(.*).
moderate | deps/npm/docs/package-lock.json | sockjs | [CVE-2020-7693](https://nvd.nist.gov/vuln/detail/CVE-2020-7693) | 5.3 | fixed in 0.3.20 | Incorrect handling of Upgrade header with the value websocket leads in crashing of containers hosting sockjs apps. This affects the package sockjs before 0.3.20.
moderate | deps/npm/docs/package-lock.json | hosted-git-info | [CVE-2021-23362](https://nvd.nist.gov/vuln/detail/CVE-2021-23362) | 5.3 | fixed in 2.8.9, 3.0.8 | The package hosted-git-info before 3.0.8 are vulnerable to Regular Expression Denial of Service (ReDoS) via regular expression shortcutMatch in the fromUrl function in index.js. The affected regular expression exhibits polynomial worst-case time complexity.
moderate | deps/npm/docs/package-lock.json | acorn | [GHSA-6chw-6frg-f759]() | 4.0 | fixed in 5.7.4, 7.1.1, 6.4.1 | Affected versions of acorn are vulnerable to Regular Expression Denial of Service. A regex in the form of /[x-\\ud800]/u causes the parser to enter an infinite loop. The string is not valid UTF16 which usually results in it being sanitized before reaching the parser. If an application processes untrusted input and passes it directly to acorn, attackers may leverage the vulnerability leading to Denial of Service.
moderate | deps/npm/docs/package-lock.json | websocket-extensions | [CVE-2020-7662](https://nvd.nist.gov/vuln/detail/CVE-2020-7662) | 7.5 | fixed in 0.1.4 | websocket-extensions npm module prior to 0.1.4 allows Denial of Service (DoS) via Regex Backtracking. The extension parser may take quadratic time when parsing a header containing an unclosed string parameter value whose content is a repeating two-byte sequence of a backslash and some other character. This could be abused by an attacker to conduct Regex Denial Of Service (ReDoS) on a single-threaded server by providing a malicious payload with the Sec-WebSocket-Extensions header.
moderate | deps/npm/docs/package-lock.json | elliptic | [CVE-2020-28498](https://github.com/advisories/GHSA-r9p9-mrjm-926w) | 6.8 | fixed in 6.5.4 | The package elliptic before 6.5.4 are vulnerable to Cryptographic Issues via the secp256k1 implementation in elliptic/ec/key.js. There is no check to confirm that the public key point passed into the derive function actually exists on the secp256k1 curve. This results in the potential for the private key used in this implementation to be revealed after a number of ECDH operations are performed.
moderate | deps/npm/docs/package-lock.json | ws | [CVE-2021-32640](https://github.com/advisories/GHSA-6fc8-4gx4-v693) | 5.3 | fixed in 5.2.3, 6.2.2, 7.4.6 | ws is an open source WebSocket client and server library for Node.js. A specially crafted value of the `Sec-Websocket-Protocol` header can be used to significantly slow down a ws server. The vulnerability has been fixed in ws@7.4.6 (https://github.com/websockets/ws/commit/00c425ec77993773d823f018f64a5c44e17023ff). In vulnerable versions of ws, the issue can be mitigated by reducing the maximum allowed length of the request headers using the [`--max-http-header-size=size`](https://nodejs.org/api/cli.html#cli_max_http_header_size_size) and/or the [`maxHeaderSize`](https://nodejs.org/api/http.html#http_http_createserver_options_requestlistener) options.
medium | deps/npm/docs/package-lock.json | flat | [PRISMA-2021-0025]() | 0.0 | fixed in 5.0.2 | flat is a Take a nested Javascript object and flatten it, or unflatten an object with delimited keys All package versions are vulnerable to Prototype Pollution. origin: https://github.com/hughsk/flat/issues/105
moderate | deps/npm/docs/package-lock.json | color-string | [CVE-2021-29060](https://github.com/advisories/GHSA-257v-vj4p-3w2h) | 5.3 | fixed in 1.5.5 | A Regular Expression Denial of Service (ReDOS) vulnerability was discovered in Color-String version 1.5.5 and below which occurs when the application is provided and checks a crafted invalid HWB string.
moderate | deps/npm/docs/package-lock.json | react-dev-utils | [CVE-2021-24033](https://github.com/advisories/GHSA-5q6m-3h65-w53x) | 5.6 | fixed in 11.0.4 | react-dev-utils prior to v11.0.4 exposes a function, getProcessForPort, where an input argument is concatenated into a command string to be executed. This function is typically used from react-scripts (in Create React App projects), where the usage is safe. Only when this function is manually invoked with user-provided values (ie: by custom code) is there the potential for command injection. If you\'re consuming it from react-scripts then this issue does not affect you.
moderate | deps/npm/docs/package-lock.json | socket.io | [CVE-2020-28481](https://nvd.nist.gov/vuln/detail/CVE-2020-28481) | 4.3 | fixed in 2.4.0 | The package socket.io before 2.4.0 are vulnerable to Insecure Defaults due to CORS Misconfiguration. All domains are whitelisted by default.
moderate | deps/npm/docs/package-lock.json | sanitize-html | [CVE-2021-26539](https://nvd.nist.gov/vuln/detail/CVE-2021-26539) | 5.3 | fixed in 2.3.1 | Apostrophe Technologies sanitize-html before 2.3.1 does not properly handle internationalized domain name (IDN) which could allow an attacker to bypass hostname whitelist validation set by the \"allowedIframeHostnames\" option.
moderate | deps/npm/docs/package-lock.json | sanitize-html | [CVE-2021-26540](https://nvd.nist.gov/vuln/detail/CVE-2021-26540) | 5.3 | fixed in 2.3.2 | Apostrophe Technologies sanitize-html before 2.3.2 does not properly validate the hostnames set by the \"allowedIframeHostnames\" option when the \"allowIframeRelativeUrls\" is set to true, which allows attackers to bypass hostname whitelist for iframe element, related using an src value that starts with \"/\\example.com\".
medium | test/fixtures/wpt/resources/webidl2/package-lock.json | braces | [CVE-2018-1109](https://nvd.nist.gov/vuln/detail/CVE-2018-1109) | 5.3 | fixed in 2.3.1 | A vulnerability was found in Braces versions prior to 2.3.1. Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks.
low | tools/node-lint-md-cli-rollup/package-lock.json | ini | [CVE-2020-7788](https://nvd.nist.gov/vuln/detail/CVE-2020-7788) | 7.3 | fixed in 1.3.6 | This affects the package ini before 1.3.6. If an attacker submits a malicious INI file to an application that parses it with ini.parse, they will pollute the prototype on the application. This can be exploited further depending on the context.
low | deps/npm/package.json | marked | [GHSA-ch52-vgq2-943f]() | 1.0 | fixed in 0.7.0 | Affected versions of `marked` are vulnerable to Regular Expression Denial of Service (ReDoS). The `_label` subrule may significantly degrade parsing performance of malformed input.   ## Recommendation  Upgrade to version 0.7.0 or later.
low | deps/v8/tools/turbolizer/package-lock.json | kind-of | [CVE-2019-20149](https://nvd.nist.gov/vuln/detail/CVE-2019-20149) | 7.5 | fixed in 6.0.3 | ctorName in index.js in kind-of v6.0.2 allows external user input to overwrite certain internal attributes via a conflicting name, as demonstrated by \'constructor\': {\'name\':\'Symbol\'}. Hence, a crafted payload can overwrite this builtin attribute to manipulate the type detection result.
low | deps/v8/tools/turbolizer/package-lock.json | minimist | [CVE-2020-7598](https://nvd.nist.gov/vuln/detail/CVE-2020-7598) | 5.6 | fixed in 1.2.3, 0.2.1 | minimist before 1.2.2 could be tricked into adding or modifying properties of Object.prototype using a \"constructor\" or \"__proto__\" payload.
low | deps/npm/docs/package-lock.json | kind-of | [CVE-2019-20149](https://nvd.nist.gov/vuln/detail/CVE-2019-20149) | 7.5 | fixed in 6.0.3 | ctorName in index.js in kind-of v6.0.2 allows external user input to overwrite certain internal attributes via a conflicting name, as demonstrated by \'constructor\': {\'name\':\'Symbol\'}. Hence, a crafted payload can overwrite this builtin attribute to manipulate the type detection result.
low | deps/npm/docs/package-lock.json | ini | [CVE-2020-7788](https://nvd.nist.gov/vuln/detail/CVE-2020-7788) | 7.3 | fixed in 1.3.6 | This affects the package ini before 1.3.6. If an attacker submits a malicious INI file to an application that parses it with ini.parse, they will pollute the prototype on the application. This can be exploited further depending on the context.
low | deps/npm/docs/package-lock.json | yargs-parser | [CVE-2020-7608](https://nvd.nist.gov/vuln/detail/CVE-2020-7608) | 5.3 | fixed in 5.0.0-security.0, 13.1.2, 18.1.2, 15.0.1 | yargs-parser could be tricked into adding or modifying properties of Object.prototype using a \"__proto__\" payload.
low | deps/npm/docs/package-lock.json | node-fetch | [CVE-2020-15168](https://nvd.nist.gov/vuln/detail/CVE-2020-15168) | 5.3 | fixed in 3.0.0-beta.9, 2.6.1 | node-fetch before versions 2.6.1 and 3.0.0-beta.9 did not honor the size option after following a redirect, which means that when a content size was over the limit, a FetchError would never get thrown and the process would end without failure. For most people, this fix will have a little or no impact. However, if you are relying on node-fetch to gate files above a size, the impact could be significant, for example: If you don\'t double-check the size of the data after fetch() has completed, your JS thread could get tied up doing work on a large file (DoS) and/or cost you money in computing.
low | deps/npm/docs/package-lock.json | minimist | [CVE-2020-7598](https://nvd.nist.gov/vuln/detail/CVE-2020-7598) | 5.6 | fixed in 1.2.3, 0.2.1 | minimist before 1.2.2 could be tricked into adding or modifying properties of Object.prototype using a \"constructor\" or \"__proto__\" payload.
low | deps/npm/docs/package-lock.json | @hapi/hoek | [GHSA-22h7-7wwg-qmgg]() | 1.0 | fixed in 9.0.3, 8.5.1 | Versions of `@hapi/hoek` prior to 8.5.1 and 9.0.3 are vulnerable to Prototype Pollution. The `clone` function fails to prevent the modification of the Object prototype when passed specially-crafted input. Attackers may use this to change existing properties that exist in all objects, which may lead to Denial of Service or Remote Code Execution in specific circumstances.   This issue __does not__ affect hapi applications since the framework protects against such malicious inputs. Applications that use `@hapi/hoek` outside of the hapi ecosystem may be vulnerable.   ## Recommendation  Update to version 8.5.1, 9.0.3 or later.
low | test/fixtures/wpt/resources/webidl2/package-lock.json | braces | [GHSA-g95f-p29q-9xw4]() | 1.0 | fixed in 2.3.1 | Versions of `braces` prior to 2.3.1 are vulnerable to Regular Expression Denial of Service (ReDoS). Untrusted input may cause catastrophic backtracking while matching regular expressions. This can cause the application to be unresponsive leading to Denial of Service.   ## Recommendation  Upgrade to version 2.3.1 or higher.
low | test/fixtures/wpt/resources/webidl2/package-lock.json | minimist | [CVE-2020-7598](https://nvd.nist.gov/vuln/detail/CVE-2020-7598) | 5.6 | fixed in 1.2.3, 0.2.1 | minimist before 1.2.2 could be tricked into adding or modifying properties of Object.prototype using a \"constructor\" or \"__proto__\" payload.
